### PR TITLE
Refactor & robust terminal restore

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -23,34 +23,34 @@ pub fn handle_event(_: &Model) -> anyhow::Result<Option<Message>> {
 }
 
 fn handle_key(key: event::KeyEvent) -> Option<Message> {
-    match key.modifiers {
+    Some(match key.modifiers {
         KeyModifiers::NONE => match key.code {
-            KeyCode::Home => Some(Message::First),
-            KeyCode::End => Some(Message::Last),
-            KeyCode::Up => Some(Message::ScrollUp),
-            KeyCode::Down => Some(Message::ScrollDown),
-            KeyCode::PageUp => Some(Message::PageUp),
-            KeyCode::PageDown => Some(Message::PageDown),
-            KeyCode::Left => Some(Message::ScrollLeft),
-            KeyCode::Right => Some(Message::ScrollRight),
-            KeyCode::Enter => Some(Message::Enter),
-            KeyCode::Esc => Some(Message::Exit),
-            KeyCode::Char('/') => Some(Message::OpenFindTask),
-            KeyCode::Backspace => Some(Message::Backspace),
-            KeyCode::Char(c) => Some(Message::CharacterInput(c)),
-            _ => None,
+            KeyCode::Home => Message::First,
+            KeyCode::End => Message::Last,
+            KeyCode::Up => Message::ScrollUp,
+            KeyCode::Down => Message::ScrollDown,
+            KeyCode::PageUp => Message::PageUp,
+            KeyCode::PageDown => Message::PageDown,
+            KeyCode::Left => Message::ScrollLeft,
+            KeyCode::Right => Message::ScrollRight,
+            KeyCode::Enter => Message::Enter,
+            KeyCode::Esc => Message::Exit,
+            KeyCode::Char('/') => Message::OpenFindTask,
+            KeyCode::Backspace => Message::Backspace,
+            KeyCode::Char(c) => Message::CharacterInput(c),
+            _ => return None,
         },
         KeyModifiers::SHIFT => match key.code {
-            KeyCode::Char(c) => Some(Message::CharacterInput(c)),
-            _ => None
-        }
-        KeyModifiers::CONTROL => match key.code {
-            KeyCode::Char('s') => Some(Message::SaveSettings),
-            KeyCode::Char('f') => Some(Message::OpenFindTask),
-            _ => None,
+            KeyCode::Char(c) => Message::CharacterInput(c),
+            _ => return None,
         },
-        _ => None,
-    }
+        KeyModifiers::CONTROL => match key.code {
+            KeyCode::Char('s') => Message::SaveSettings,
+            KeyCode::Char('f') => Message::OpenFindTask,
+            _ => return None,
+        },
+        _ => return None,
+    })
 }
 
 fn handle_resize(

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod terminal;
 use crate::model::{Model, Screen};
 use crate::props::Props;
 use crate::raw_json_lines::{RawJsonLines, SourceName};
-use anyhow::{anyhow, Context};
+use anyhow::{Context, anyhow};
 use clap::Parser;
 use std::fs::File;
 use std::io;
@@ -48,10 +48,13 @@ fn main() -> anyhow::Result<()> {
 
     while model.active_screen != Screen::Done {
         // Render the current view
-        terminal.draw(|f| terminal::view(&mut model, f)).map_err(|e| anyhow!("{e}")).context("failed to draw to terminal")?;
+        terminal
+            .draw(|f| terminal::view(&mut model, f))
+            .map_err(|e| anyhow!("{e}"))
+            .context("failed to draw to terminal")?;
 
         // Handle events and map to a Message
-        let mut current_msg = event::handle_event(&model)?;
+        let mut current_msg = event::handle_event(&model).context("failed to handle event")?;
 
         // Process updates as long as they return a non-None message
         while let Some(msg) = current_msg {
@@ -61,7 +64,8 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    terminal::restore_terminal()?;
+    terminal::restore_terminal().context("failed to restore terminal state")?;
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,13 +66,16 @@ fn main() -> anyhow::Result<()> {
 }
 
 fn init_props(args: &Args) -> anyhow::Result<Props> {
-    let mut props = Props::init()?;
+    let mut props = Props::init().context("failed to load props")?;
+
     if let Some(e) = &args.field_order {
         props.fields_order = e.clone();
     }
+
     if let Some(e) = &args.suppressed_fields {
         props.fields_suppressed = e.clone();
     }
+
     Ok(props)
 }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -372,15 +372,19 @@ impl<'a> Model<'a> {
     }
 
     pub fn render_status_line_left(&self) -> String {
-        match self.view_state.main_window_list_state.selected() {
-            Some(line_nr) if self.raw_json_lines.lines.len() > line_nr => {
-                let raw_line = &self.raw_json_lines.lines[line_nr];
-                let source_name = self.raw_json_lines.source_name(raw_line.source_id).expect("invalid source id");
-                format!("{}:{}", source_name, raw_line.line_nr)
-            }
-            _ => String::new(),
-        }
+        let Some(line_nr) = self.view_state.main_window_list_state.selected() else {
+            return "".into();
+        };
+
+        let Some(raw_line) = self.raw_json_lines.lines.get(line_nr) else {
+            return "".into();
+        };
+
+        let source_name = self.raw_json_lines.source_name(raw_line.source_id).expect("invalid source id");
+
+        format!("{}:{}", source_name, raw_line.line_nr)
     }
+
     pub fn render_status_line_right(&self) -> String {
         self.last_action_result.clone()
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -404,15 +404,18 @@ impl<'a> Model<'a> {
     }
 
     pub fn render_find_task_line_right(&self) -> Line {
-        if let Some(t) = self.find_task.as_ref() {
-            if let Some(state) = t.found {
-                return match state {
-                    true => "found".to_owned().into(),
-                    false => "NOT found".to_owned().into(),
-                }
-            }
+        let Some(task) = &self.find_task else {
+            return "".into();
+        };
+
+        let Some(found) = task.found else {
+            return "".into();
+        };
+
+        match found {
+            true => "found".into(),
+            false => "NOT found".into(),
         }
-        "".into()
     }
 
     pub fn page_len(&self) -> u16 {

--- a/src/model.rs
+++ b/src/model.rs
@@ -522,7 +522,7 @@ pub struct ModelIntoIter<'a> {
     index: usize,
 }
 
-impl<'a> ModelIntoIter<'a> {
+impl ModelIntoIter<'_> {
     // light version of Self::next() that simply skips the item.
     // returns true if the item was skipped, false if there are no more items
     fn skip_item(&mut self) -> bool {

--- a/src/model.rs
+++ b/src/model.rs
@@ -386,21 +386,24 @@ impl<'a> Model<'a> {
     }
 
     pub fn render_find_task_line_left(&self) -> Line {
-        if let Some(task) = self.find_task.as_ref() {
-            let color = match task.found {
-                None => Color::default(),
-                Some(false) => Color::Red,
-                Some(true) => Color::Green
-            };
-            " [".to_span().set_style(color)
-                .add("Find ".to_span())
-                .add("🔍".to_span())
-                .add(": ".bold())
-                .add(task.search_string.to_span().bold())
-                .add("  ] ".to_span().set_style(color)).to_owned()
-        } else {
-            Line::raw("").to_owned()
-        }
+        let Some(task) = &self.find_task else {
+            return "".into();
+        };
+
+        let color = match task.found {
+            None => Color::default(),
+            Some(false) => Color::Red,
+            Some(true) => Color::Green,
+        };
+
+        " [".to_span()
+            .set_style(color)
+            .add("Find ".to_span())
+            .add("🔍".to_span())
+            .add(": ".bold())
+            .add(task.search_string.to_span().bold())
+            .add("  ] ".to_span().set_style(color))
+            .to_owned()
     }
 
     pub fn render_find_task_line_right(&self) -> Line {

--- a/src/props.rs
+++ b/src/props.rs
@@ -26,12 +26,11 @@ impl Props {
     }
 
     pub fn save(&self) -> anyhow::Result<()> {
-        match Self::config_file_path() {
-            None => Err(anyhow!("Config dir not found")),
-            Some(f) => {
-                std::fs::write(&f, toml::to_string_pretty(self)?)?;
-                Ok(())
-            }
-        }
+        let f = Self::config_file_path().context("Config dir not found")?;
+        let toml = toml::to_string_pretty(self)?;
+
+        std::fs::write(&f, toml)?;
+
+        Ok(())
     }
 }

--- a/src/props.rs
+++ b/src/props.rs
@@ -1,5 +1,6 @@
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use serde::{Deserialize, Serialize};
+use std::fs;
 use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Default, Clone)]
@@ -14,12 +15,14 @@ impl Props {
     }
 
     pub fn init() -> anyhow::Result<Props> {
-        match &Self::config_file_path() {
-            Some(f) if f.exists() => Ok(toml::from_str(
-                &std::fs::read_to_string(f).map_err(|e| anyhow!("'{}' - while reading file {}", e, f.to_string_lossy()))?,
-            )?),
-            _ => Ok(Props::default()),
-        }
+        let Some(f) = &Self::config_file_path().filter(|f| f.exists()) else {
+            return Ok(Props::default());
+        };
+
+        let props = fs::read_to_string(f).with_context(|| format!("failed to read config file {f:?}"))?;
+        let props = toml::from_str::<Props>(&props).context("failed to parse config file as toml")?;
+
+        Ok(props)
     }
 
     pub fn save(&self) -> anyhow::Result<()> {

--- a/src/raw_json_lines.rs
+++ b/src/raw_json_lines.rs
@@ -72,21 +72,22 @@ pub struct RawJsonLine {
 impl RawJsonLine {
     /// returns JSON object lines and keys in rendered order
     pub fn produce_rendered_fields_as_list(&self, key_order: &[String]) -> (Vec<String>, Vec<String>) {
-        if let serde_json::Value::Object(o) = serde_json::from_str(&self.content).expect("not a json value") {
+        let value = serde_json::from_str(&self.content).expect("not a json value");
 
-            let mut keys_in_rendered_order: Vec<_> = key_order.iter().filter(|&e| o.contains_key(e)).cloned().collect();
-            keys_in_rendered_order.extend(o.keys().filter(|&e| !key_order.contains(e)).cloned());
-
-            let mut list_items = vec![];
-
-            for k in &keys_in_rendered_order {
-                list_items.push(Self::render_attribute(k, o.get(k).unwrap()));
-            }
-
-            (list_items, keys_in_rendered_order)
-        } else {
+        let serde_json::Value::Object(o) = value else {
             panic!("line should be in json object format")
+        };
+
+        let mut keys_in_rendered_order: Vec<_> = key_order.iter().filter(|&e| o.contains_key(e)).cloned().collect();
+        keys_in_rendered_order.extend(o.keys().filter(|&e| !key_order.contains(e)).cloned());
+
+        let mut list_items = vec![];
+
+        for k in &keys_in_rendered_order {
+            list_items.push(Self::render_attribute(k, o.get(k).unwrap()));
         }
+
+        (list_items, keys_in_rendered_order)
     }
 
     fn render_attribute(key: &str, value: &serde_json::Value) -> String {


### PR DESCRIPTION
This PR refactors most of the smaller functions.
The most significant refactoring changes include:

- using [`let-else`](https://doc.rust-lang.org/rust-by-example/flow_control/let_else.html) to reduce nesting
- using `.context()` / `.with_context()` to add context to anyhow's errors
- liberal use of variables to prevent long lines

Additionally, the main app loop got extracted from `main` into the `run_app` function.
The reason for this is to ensure that the terminal is always getting restored properly,
even if the app returns an error.

I'm very tempted to also split up some of the larger functions and move some stuff into new modules, but last time I tried that I ended up with nasty merge conflicts 🥲.